### PR TITLE
fix(ci): use PAT in release-please to trigger goreleaser

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -11,6 +11,6 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
## Summary
- GITHUB_TOKEN-created tags don't trigger other workflows (GitHub limitation)
- Switch release-please to use HOMEBREW_TAP_TOKEN so v* tags fire goreleaser

## Test plan
- Merge this PR, release-please runs, creates tag, goreleaser triggers