### PR TITLE
fix: set homebrew cask name to kh

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -28,7 +28,8 @@ archives:
 checksum:
   name_template: checksums.txt
 homebrew_casks:
-  - repository:
+  - name: kh
+    repository:
       owner: keeperhub
       name: homebrew-tap
       token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"


### PR DESCRIPTION
## Summary
- GoReleaser defaults the cask name to the Go module name (`cli`) when no explicit `name` field is set in `homebrew_casks`
- This caused the generated cask to be `Casks/cli.rb` instead of `Casks/kh.rb`, making `brew install keeperhub/tap/kh` fail
- Adds `name: kh` to the `homebrew_casks` config so the next release publishes as `kh.rb`

## Test plan
- [ ] Merge to main, wait for release-please PR
- [ ] Merge release PR, confirm goreleaser generates `Casks/kh.rb` in homebrew-tap repo
- [ ] Run `brew tap keeperhub/tap && brew install keeperhub/tap/kh`
- [ ] Verify `kh version` prints the tagged version