### PR TITLE
fix: change default host from app.keeperhub.io to app.keeperhub.com

### DIFF
--- a/cmd/auth/login_test.go
+++ b/cmd/auth/login_test.go
@@ -42,7 +42,7 @@ func TestLoginCmd_BrowserFlow(t *testing.T) {
 		t.Error("expected BrowserLogin to be called")
 	}
 	out := buf.String()
-	if !strings.Contains(out, "app.keeperhub.io") {
+	if !strings.Contains(out, "app.keeperhub.com") {
 		t.Errorf("expected host in output, got: %q", out)
 	}
 }

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -13,7 +13,7 @@ func NewConfigCmd(f *cmdutil.Factory) *cobra.Command {
   kh config ls
 
   # Set the default host
-  kh config set default_host app.keeperhub.io`,
+  kh config set default_host app.keeperhub.com`,
 	}
 
 	cmd.AddCommand(NewSetCmd(f))

--- a/cmd/config/set.go
+++ b/cmd/config/set.go
@@ -19,7 +19,7 @@ all valid keys.
 
 See also: kh config list, kh config get`,
 		Example: `  # Set the default host
-  kh config set default_host app.keeperhub.io
+  kh config set default_host app.keeperhub.com
 
   # Point CLI at a self-hosted instance
   kh config set default_host https://kh.mycompany.io`,

--- a/cmd/doctor/doctor.go
+++ b/cmd/doctor/doctor.go
@@ -134,7 +134,7 @@ func getHost(f *cmdutil.Factory) (string, error) {
 	}
 	host := cfg.DefaultHost
 	if host == "" {
-		host = "app.keeperhub.io"
+		host = "app.keeperhub.com"
 	}
 	return host, nil
 }

--- a/cmd/help/topics.go
+++ b/cmd/help/topics.go
@@ -9,7 +9,7 @@ func NewEnvironmentTopic() *cobra.Command {
 		Use:   "environment",
 		Short: "Environment variables used by kh",
 		Long: `KH_HOST
-  Override the KeeperHub API host. Default: app.keeperhub.io
+  Override the KeeperHub API host. Default: app.keeperhub.com
   Example: KH_HOST=https://kh.mycompany.io kh workflow list
 
 KH_API_KEY

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -38,7 +38,7 @@ func NewRootCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd.PersistentFlags().String("jq", "", "Filter JSON output with a jq expression")
 	cmd.PersistentFlags().BoolP("yes", "y", false, "Skip confirmation prompts")
 	cmd.PersistentFlags().Bool("no-color", false, "Disable color output")
-	cmd.PersistentFlags().StringP("host", "H", "", "KeeperHub host (default: app.keeperhub.io)")
+	cmd.PersistentFlags().StringP("host", "H", "", "KeeperHub host (default: app.keeperhub.com)")
 
 	cmd.AddCommand(action.NewActionCmd(f))
 	cmd.AddCommand(auth.NewAuthCmd(f))

--- a/cmd/run/cancel.go
+++ b/cmd/run/cancel.go
@@ -48,7 +48,7 @@ func NewCancelCmd(f *cmdutil.Factory) *cobra.Command {
 				host = cfg.DefaultHost
 			}
 			if host == "" {
-				host = "app.keeperhub.io"
+				host = "app.keeperhub.com"
 			}
 
 			// Confirmation: skip if --yes or non-TTY (auto-proceed in non-interactive mode).

--- a/cmd/run/logs.go
+++ b/cmd/run/logs.go
@@ -94,7 +94,7 @@ func NewLogsCmd(f *cmdutil.Factory) *cobra.Command {
 				host = cfg.DefaultHost
 			}
 			if host == "" {
-				host = "app.keeperhub.io"
+				host = "app.keeperhub.com"
 			}
 
 			url := khhttp.BuildBaseURL(host) + "/api/workflows/executions/" + runID + "/logs"

--- a/cmd/run/status.go
+++ b/cmd/run/status.go
@@ -78,7 +78,7 @@ See also: kh r l, kh r cancel, kh wf run`,
 				host = cfg.DefaultHost
 			}
 			if host == "" {
-				host = "app.keeperhub.io"
+				host = "app.keeperhub.com"
 			}
 
 			watch, _ := cmd.Flags().GetBool("watch")

--- a/docs/kh.md
+++ b/docs/kh.md
@@ -6,7 +6,7 @@ KeeperHub CLI
 
 ```
   -h, --help          help for kh
-  -H, --host string   KeeperHub host (default: app.keeperhub.io)
+  -H, --host string   KeeperHub host (default: app.keeperhub.com)
       --jq string     Filter JSON output with a jq expression
       --json          Output as JSON
       --no-color      Disable color output

--- a/docs/kh_action.md
+++ b/docs/kh_action.md
@@ -23,7 +23,7 @@ Browse available actions
 ### Options inherited from parent commands
 
 ```
-  -H, --host string   KeeperHub host (default: app.keeperhub.io)
+  -H, --host string   KeeperHub host (default: app.keeperhub.com)
       --no-color      Disable color output
   -y, --yes           Skip confirmation prompts
 ```

--- a/docs/kh_action_get.md
+++ b/docs/kh_action_get.md
@@ -25,7 +25,7 @@ kh action get <action-name> [flags]
 ### Options inherited from parent commands
 
 ```
-  -H, --host string   KeeperHub host (default: app.keeperhub.io)
+  -H, --host string   KeeperHub host (default: app.keeperhub.com)
       --jq string     Filter JSON output with a jq expression
       --json          Output as JSON
       --no-color      Disable color output

--- a/docs/kh_action_list.md
+++ b/docs/kh_action_list.md
@@ -26,7 +26,7 @@ kh action list [flags]
 ### Options inherited from parent commands
 
 ```
-  -H, --host string   KeeperHub host (default: app.keeperhub.io)
+  -H, --host string   KeeperHub host (default: app.keeperhub.com)
       --jq string     Filter JSON output with a jq expression
       --json          Output as JSON
       --no-color      Disable color output

--- a/docs/kh_auth.md
+++ b/docs/kh_auth.md
@@ -21,7 +21,7 @@ Authenticate with KeeperHub
 ### Options inherited from parent commands
 
 ```
-  -H, --host string   KeeperHub host (default: app.keeperhub.io)
+  -H, --host string   KeeperHub host (default: app.keeperhub.com)
       --jq string     Filter JSON output with a jq expression
       --json          Output as JSON
       --no-color      Disable color output

--- a/docs/kh_auth_login.md
+++ b/docs/kh_auth_login.md
@@ -35,7 +35,7 @@ kh auth login [flags]
 ### Options inherited from parent commands
 
 ```
-  -H, --host string   KeeperHub host (default: app.keeperhub.io)
+  -H, --host string   KeeperHub host (default: app.keeperhub.com)
       --jq string     Filter JSON output with a jq expression
       --json          Output as JSON
       --no-color      Disable color output

--- a/docs/kh_auth_logout.md
+++ b/docs/kh_auth_logout.md
@@ -32,7 +32,7 @@ kh auth logout [flags]
 ### Options inherited from parent commands
 
 ```
-  -H, --host string   KeeperHub host (default: app.keeperhub.io)
+  -H, --host string   KeeperHub host (default: app.keeperhub.com)
       --jq string     Filter JSON output with a jq expression
       --json          Output as JSON
       --no-color      Disable color output

--- a/docs/kh_auth_status.md
+++ b/docs/kh_auth_status.md
@@ -25,7 +25,7 @@ kh auth status [flags]
 ### Options inherited from parent commands
 
 ```
-  -H, --host string   KeeperHub host (default: app.keeperhub.io)
+  -H, --host string   KeeperHub host (default: app.keeperhub.com)
       --jq string     Filter JSON output with a jq expression
       --json          Output as JSON
       --no-color      Disable color output

--- a/docs/kh_billing.md
+++ b/docs/kh_billing.md
@@ -23,7 +23,7 @@ View billing and usage
 ### Options inherited from parent commands
 
 ```
-  -H, --host string   KeeperHub host (default: app.keeperhub.io)
+  -H, --host string   KeeperHub host (default: app.keeperhub.com)
       --no-color      Disable color output
   -y, --yes           Skip confirmation prompts
 ```

--- a/docs/kh_billing_status.md
+++ b/docs/kh_billing_status.md
@@ -25,7 +25,7 @@ kh billing status [flags]
 ### Options inherited from parent commands
 
 ```
-  -H, --host string   KeeperHub host (default: app.keeperhub.io)
+  -H, --host string   KeeperHub host (default: app.keeperhub.com)
       --jq string     Filter JSON output with a jq expression
       --json          Output as JSON
       --no-color      Disable color output

--- a/docs/kh_billing_usage.md
+++ b/docs/kh_billing_usage.md
@@ -26,7 +26,7 @@ kh billing usage [flags]
 ### Options inherited from parent commands
 
 ```
-  -H, --host string   KeeperHub host (default: app.keeperhub.io)
+  -H, --host string   KeeperHub host (default: app.keeperhub.com)
       --jq string     Filter JSON output with a jq expression
       --json          Output as JSON
       --no-color      Disable color output

--- a/docs/kh_completion.md
+++ b/docs/kh_completion.md
@@ -32,7 +32,7 @@ kh completion <shell> [flags]
 ### Options inherited from parent commands
 
 ```
-  -H, --host string   KeeperHub host (default: app.keeperhub.io)
+  -H, --host string   KeeperHub host (default: app.keeperhub.com)
       --jq string     Filter JSON output with a jq expression
       --json          Output as JSON
       --no-color      Disable color output

--- a/docs/kh_config.md
+++ b/docs/kh_config.md
@@ -9,7 +9,7 @@ Manage CLI configuration
   kh config ls
 
   # Set the default host
-  kh config set default_host app.keeperhub.io
+  kh config set default_host app.keeperhub.com
 ```
 
 ### Options
@@ -21,7 +21,7 @@ Manage CLI configuration
 ### Options inherited from parent commands
 
 ```
-  -H, --host string   KeeperHub host (default: app.keeperhub.io)
+  -H, --host string   KeeperHub host (default: app.keeperhub.com)
       --jq string     Filter JSON output with a jq expression
       --json          Output as JSON
       --no-color      Disable color output

--- a/docs/kh_config_get.md
+++ b/docs/kh_config_get.md
@@ -22,7 +22,7 @@ kh config get <key> [flags]
 ### Options inherited from parent commands
 
 ```
-  -H, --host string   KeeperHub host (default: app.keeperhub.io)
+  -H, --host string   KeeperHub host (default: app.keeperhub.com)
       --jq string     Filter JSON output with a jq expression
       --json          Output as JSON
       --no-color      Disable color output

--- a/docs/kh_config_list.md
+++ b/docs/kh_config_list.md
@@ -22,7 +22,7 @@ kh config list [flags]
 ### Options inherited from parent commands
 
 ```
-  -H, --host string   KeeperHub host (default: app.keeperhub.io)
+  -H, --host string   KeeperHub host (default: app.keeperhub.com)
       --jq string     Filter JSON output with a jq expression
       --json          Output as JSON
       --no-color      Disable color output

--- a/docs/kh_config_set.md
+++ b/docs/kh_config_set.md
@@ -18,7 +18,7 @@ kh config set <key> <value> [flags]
 
 ```
   # Set the default host
-  kh config set default_host app.keeperhub.io
+  kh config set default_host app.keeperhub.com
 
   # Point CLI at a self-hosted instance
   kh config set default_host https://kh.mycompany.io
@@ -33,7 +33,7 @@ kh config set <key> <value> [flags]
 ### Options inherited from parent commands
 
 ```
-  -H, --host string   KeeperHub host (default: app.keeperhub.io)
+  -H, --host string   KeeperHub host (default: app.keeperhub.com)
       --jq string     Filter JSON output with a jq expression
       --json          Output as JSON
       --no-color      Disable color output

--- a/docs/kh_doctor.md
+++ b/docs/kh_doctor.md
@@ -33,7 +33,7 @@ kh doctor [flags]
 ### Options inherited from parent commands
 
 ```
-  -H, --host string   KeeperHub host (default: app.keeperhub.io)
+  -H, --host string   KeeperHub host (default: app.keeperhub.com)
       --jq string     Filter JSON output with a jq expression
       --json          Output as JSON
       --no-color      Disable color output

--- a/docs/kh_execute.md
+++ b/docs/kh_execute.md
@@ -29,7 +29,7 @@ See also: kh r st, kh wf run
 ### Options inherited from parent commands
 
 ```
-  -H, --host string   KeeperHub host (default: app.keeperhub.io)
+  -H, --host string   KeeperHub host (default: app.keeperhub.com)
       --jq string     Filter JSON output with a jq expression
       --json          Output as JSON
       --no-color      Disable color output

--- a/docs/kh_execute_contract-call.md
+++ b/docs/kh_execute_contract-call.md
@@ -32,7 +32,7 @@ kh execute contract-call [flags]
 ### Options inherited from parent commands
 
 ```
-  -H, --host string   KeeperHub host (default: app.keeperhub.io)
+  -H, --host string   KeeperHub host (default: app.keeperhub.com)
       --jq string     Filter JSON output with a jq expression
       --json          Output as JSON
       --no-color      Disable color output

--- a/docs/kh_execute_status.md
+++ b/docs/kh_execute_status.md
@@ -33,7 +33,7 @@ kh execute status <execution-id> [flags]
 ### Options inherited from parent commands
 
 ```
-  -H, --host string   KeeperHub host (default: app.keeperhub.io)
+  -H, --host string   KeeperHub host (default: app.keeperhub.com)
       --jq string     Filter JSON output with a jq expression
       --json          Output as JSON
       --no-color      Disable color output

--- a/docs/kh_execute_transfer.md
+++ b/docs/kh_execute_transfer.md
@@ -32,7 +32,7 @@ kh execute transfer [flags]
 ### Options inherited from parent commands
 
 ```
-  -H, --host string   KeeperHub host (default: app.keeperhub.io)
+  -H, --host string   KeeperHub host (default: app.keeperhub.com)
       --jq string     Filter JSON output with a jq expression
       --json          Output as JSON
       --no-color      Disable color output

--- a/docs/kh_org.md
+++ b/docs/kh_org.md
@@ -23,7 +23,7 @@ Manage organizations
 ### Options inherited from parent commands
 
 ```
-  -H, --host string   KeeperHub host (default: app.keeperhub.io)
+  -H, --host string   KeeperHub host (default: app.keeperhub.com)
       --no-color      Disable color output
   -y, --yes           Skip confirmation prompts
 ```

--- a/docs/kh_org_list.md
+++ b/docs/kh_org_list.md
@@ -25,7 +25,7 @@ kh org list [flags]
 ### Options inherited from parent commands
 
 ```
-  -H, --host string   KeeperHub host (default: app.keeperhub.io)
+  -H, --host string   KeeperHub host (default: app.keeperhub.com)
       --jq string     Filter JSON output with a jq expression
       --json          Output as JSON
       --no-color      Disable color output

--- a/docs/kh_org_members.md
+++ b/docs/kh_org_members.md
@@ -25,7 +25,7 @@ kh org members [flags]
 ### Options inherited from parent commands
 
 ```
-  -H, --host string   KeeperHub host (default: app.keeperhub.io)
+  -H, --host string   KeeperHub host (default: app.keeperhub.com)
       --jq string     Filter JSON output with a jq expression
       --json          Output as JSON
       --no-color      Disable color output

--- a/docs/kh_org_switch.md
+++ b/docs/kh_org_switch.md
@@ -25,7 +25,7 @@ kh org switch <org-slug> [flags]
 ### Options inherited from parent commands
 
 ```
-  -H, --host string   KeeperHub host (default: app.keeperhub.io)
+  -H, --host string   KeeperHub host (default: app.keeperhub.com)
       --jq string     Filter JSON output with a jq expression
       --json          Output as JSON
       --no-color      Disable color output

--- a/docs/kh_project.md
+++ b/docs/kh_project.md
@@ -24,7 +24,7 @@ Manage projects
 ### Options inherited from parent commands
 
 ```
-  -H, --host string   KeeperHub host (default: app.keeperhub.io)
+  -H, --host string   KeeperHub host (default: app.keeperhub.com)
       --no-color      Disable color output
 ```
 

--- a/docs/kh_project_create.md
+++ b/docs/kh_project_create.md
@@ -26,7 +26,7 @@ kh project create <name> [flags]
 ### Options inherited from parent commands
 
 ```
-  -H, --host string   KeeperHub host (default: app.keeperhub.io)
+  -H, --host string   KeeperHub host (default: app.keeperhub.com)
       --jq string     Filter JSON output with a jq expression
       --json          Output as JSON
       --no-color      Disable color output

--- a/docs/kh_project_delete.md
+++ b/docs/kh_project_delete.md
@@ -25,7 +25,7 @@ kh project delete <project-id> [flags]
 ### Options inherited from parent commands
 
 ```
-  -H, --host string   KeeperHub host (default: app.keeperhub.io)
+  -H, --host string   KeeperHub host (default: app.keeperhub.com)
       --jq string     Filter JSON output with a jq expression
       --json          Output as JSON
       --no-color      Disable color output

--- a/docs/kh_project_get.md
+++ b/docs/kh_project_get.md
@@ -25,7 +25,7 @@ kh project get <project-id> [flags]
 ### Options inherited from parent commands
 
 ```
-  -H, --host string   KeeperHub host (default: app.keeperhub.io)
+  -H, --host string   KeeperHub host (default: app.keeperhub.com)
       --jq string     Filter JSON output with a jq expression
       --json          Output as JSON
       --no-color      Disable color output

--- a/docs/kh_project_list.md
+++ b/docs/kh_project_list.md
@@ -26,7 +26,7 @@ kh project list [flags]
 ### Options inherited from parent commands
 
 ```
-  -H, --host string   KeeperHub host (default: app.keeperhub.io)
+  -H, --host string   KeeperHub host (default: app.keeperhub.com)
       --jq string     Filter JSON output with a jq expression
       --json          Output as JSON
       --no-color      Disable color output

--- a/docs/kh_protocol.md
+++ b/docs/kh_protocol.md
@@ -21,7 +21,7 @@ Browse blockchain protocols
 ### Options inherited from parent commands
 
 ```
-  -H, --host string   KeeperHub host (default: app.keeperhub.io)
+  -H, --host string   KeeperHub host (default: app.keeperhub.com)
       --jq string     Filter JSON output with a jq expression
       --json          Output as JSON
       --no-color      Disable color output

--- a/docs/kh_protocol_get.md
+++ b/docs/kh_protocol_get.md
@@ -25,7 +25,7 @@ kh protocol get <protocol-slug> [flags]
 ### Options inherited from parent commands
 
 ```
-  -H, --host string   KeeperHub host (default: app.keeperhub.io)
+  -H, --host string   KeeperHub host (default: app.keeperhub.com)
       --jq string     Filter JSON output with a jq expression
       --json          Output as JSON
       --no-color      Disable color output

--- a/docs/kh_protocol_list.md
+++ b/docs/kh_protocol_list.md
@@ -26,7 +26,7 @@ kh protocol list [flags]
 ### Options inherited from parent commands
 
 ```
-  -H, --host string   KeeperHub host (default: app.keeperhub.io)
+  -H, --host string   KeeperHub host (default: app.keeperhub.com)
       --jq string     Filter JSON output with a jq expression
       --json          Output as JSON
       --no-color      Disable color output

--- a/docs/kh_run.md
+++ b/docs/kh_run.md
@@ -21,7 +21,7 @@ Monitor workflow runs
 ### Options inherited from parent commands
 
 ```
-  -H, --host string   KeeperHub host (default: app.keeperhub.io)
+  -H, --host string   KeeperHub host (default: app.keeperhub.com)
       --jq string     Filter JSON output with a jq expression
       --json          Output as JSON
       --no-color      Disable color output

--- a/docs/kh_run_cancel.md
+++ b/docs/kh_run_cancel.md
@@ -25,7 +25,7 @@ kh run cancel <run-id> [flags]
 ### Options inherited from parent commands
 
 ```
-  -H, --host string   KeeperHub host (default: app.keeperhub.io)
+  -H, --host string   KeeperHub host (default: app.keeperhub.com)
       --jq string     Filter JSON output with a jq expression
       --json          Output as JSON
       --no-color      Disable color output

--- a/docs/kh_run_logs.md
+++ b/docs/kh_run_logs.md
@@ -25,7 +25,7 @@ kh run logs <run-id> [flags]
 ### Options inherited from parent commands
 
 ```
-  -H, --host string   KeeperHub host (default: app.keeperhub.io)
+  -H, --host string   KeeperHub host (default: app.keeperhub.com)
       --jq string     Filter JSON output with a jq expression
       --json          Output as JSON
       --no-color      Disable color output

--- a/docs/kh_run_status.md
+++ b/docs/kh_run_status.md
@@ -34,7 +34,7 @@ kh run status <run-id> [flags]
 ### Options inherited from parent commands
 
 ```
-  -H, --host string   KeeperHub host (default: app.keeperhub.io)
+  -H, --host string   KeeperHub host (default: app.keeperhub.com)
       --jq string     Filter JSON output with a jq expression
       --json          Output as JSON
       --no-color      Disable color output

--- a/docs/kh_serve.md
+++ b/docs/kh_serve.md
@@ -34,7 +34,7 @@ kh serve [flags]
 ### Options inherited from parent commands
 
 ```
-  -H, --host string   KeeperHub host (default: app.keeperhub.io)
+  -H, --host string   KeeperHub host (default: app.keeperhub.com)
       --jq string     Filter JSON output with a jq expression
       --json          Output as JSON
       --no-color      Disable color output

--- a/docs/kh_tag.md
+++ b/docs/kh_tag.md
@@ -24,7 +24,7 @@ Manage tags
 ### Options inherited from parent commands
 
 ```
-  -H, --host string   KeeperHub host (default: app.keeperhub.io)
+  -H, --host string   KeeperHub host (default: app.keeperhub.com)
       --no-color      Disable color output
 ```
 

--- a/docs/kh_tag_create.md
+++ b/docs/kh_tag_create.md
@@ -26,7 +26,7 @@ kh tag create <name> [flags]
 ### Options inherited from parent commands
 
 ```
-  -H, --host string   KeeperHub host (default: app.keeperhub.io)
+  -H, --host string   KeeperHub host (default: app.keeperhub.com)
       --jq string     Filter JSON output with a jq expression
       --json          Output as JSON
       --no-color      Disable color output

--- a/docs/kh_tag_delete.md
+++ b/docs/kh_tag_delete.md
@@ -25,7 +25,7 @@ kh tag delete <tag-id> [flags]
 ### Options inherited from parent commands
 
 ```
-  -H, --host string   KeeperHub host (default: app.keeperhub.io)
+  -H, --host string   KeeperHub host (default: app.keeperhub.com)
       --jq string     Filter JSON output with a jq expression
       --json          Output as JSON
       --no-color      Disable color output

--- a/docs/kh_tag_get.md
+++ b/docs/kh_tag_get.md
@@ -25,7 +25,7 @@ kh tag get <tag-id> [flags]
 ### Options inherited from parent commands
 
 ```
-  -H, --host string   KeeperHub host (default: app.keeperhub.io)
+  -H, --host string   KeeperHub host (default: app.keeperhub.com)
       --jq string     Filter JSON output with a jq expression
       --json          Output as JSON
       --no-color      Disable color output

--- a/docs/kh_tag_list.md
+++ b/docs/kh_tag_list.md
@@ -26,7 +26,7 @@ kh tag list [flags]
 ### Options inherited from parent commands
 
 ```
-  -H, --host string   KeeperHub host (default: app.keeperhub.io)
+  -H, --host string   KeeperHub host (default: app.keeperhub.com)
       --jq string     Filter JSON output with a jq expression
       --json          Output as JSON
       --no-color      Disable color output

--- a/docs/kh_template.md
+++ b/docs/kh_template.md
@@ -23,7 +23,7 @@ Manage workflow templates
 ### Options inherited from parent commands
 
 ```
-  -H, --host string   KeeperHub host (default: app.keeperhub.io)
+  -H, --host string   KeeperHub host (default: app.keeperhub.com)
       --no-color      Disable color output
   -y, --yes           Skip confirmation prompts
 ```

--- a/docs/kh_template_deploy.md
+++ b/docs/kh_template_deploy.md
@@ -26,7 +26,7 @@ kh template deploy <template-id> [flags]
 ### Options inherited from parent commands
 
 ```
-  -H, --host string   KeeperHub host (default: app.keeperhub.io)
+  -H, --host string   KeeperHub host (default: app.keeperhub.com)
       --jq string     Filter JSON output with a jq expression
       --json          Output as JSON
       --no-color      Disable color output

--- a/docs/kh_template_list.md
+++ b/docs/kh_template_list.md
@@ -25,7 +25,7 @@ kh template list [flags]
 ### Options inherited from parent commands
 
 ```
-  -H, --host string   KeeperHub host (default: app.keeperhub.io)
+  -H, --host string   KeeperHub host (default: app.keeperhub.com)
       --jq string     Filter JSON output with a jq expression
       --json          Output as JSON
       --no-color      Disable color output

--- a/docs/kh_update.md
+++ b/docs/kh_update.md
@@ -30,7 +30,7 @@ kh update [flags]
 ### Options inherited from parent commands
 
 ```
-  -H, --host string   KeeperHub host (default: app.keeperhub.io)
+  -H, --host string   KeeperHub host (default: app.keeperhub.com)
       --jq string     Filter JSON output with a jq expression
       --json          Output as JSON
       --no-color      Disable color output

--- a/docs/kh_version.md
+++ b/docs/kh_version.md
@@ -22,7 +22,7 @@ kh version [flags]
 ### Options inherited from parent commands
 
 ```
-  -H, --host string   KeeperHub host (default: app.keeperhub.io)
+  -H, --host string   KeeperHub host (default: app.keeperhub.com)
       --jq string     Filter JSON output with a jq expression
       --json          Output as JSON
       --no-color      Disable color output

--- a/docs/kh_wallet.md
+++ b/docs/kh_wallet.md
@@ -23,7 +23,7 @@ Manage wallets
 ### Options inherited from parent commands
 
 ```
-  -H, --host string   KeeperHub host (default: app.keeperhub.io)
+  -H, --host string   KeeperHub host (default: app.keeperhub.com)
       --no-color      Disable color output
   -y, --yes           Skip confirmation prompts
 ```

--- a/docs/kh_wallet_balance.md
+++ b/docs/kh_wallet_balance.md
@@ -26,7 +26,7 @@ kh wallet balance [flags]
 ### Options inherited from parent commands
 
 ```
-  -H, --host string   KeeperHub host (default: app.keeperhub.io)
+  -H, --host string   KeeperHub host (default: app.keeperhub.com)
       --jq string     Filter JSON output with a jq expression
       --json          Output as JSON
       --no-color      Disable color output

--- a/docs/kh_wallet_tokens.md
+++ b/docs/kh_wallet_tokens.md
@@ -27,7 +27,7 @@ kh wallet tokens [flags]
 ### Options inherited from parent commands
 
 ```
-  -H, --host string   KeeperHub host (default: app.keeperhub.io)
+  -H, --host string   KeeperHub host (default: app.keeperhub.com)
       --jq string     Filter JSON output with a jq expression
       --json          Output as JSON
       --no-color      Disable color output

--- a/docs/kh_workflow.md
+++ b/docs/kh_workflow.md
@@ -23,7 +23,7 @@ Manage workflows
 ### Options inherited from parent commands
 
 ```
-  -H, --host string   KeeperHub host (default: app.keeperhub.io)
+  -H, --host string   KeeperHub host (default: app.keeperhub.com)
       --no-color      Disable color output
   -y, --yes           Skip confirmation prompts
 ```

--- a/docs/kh_workflow_get.md
+++ b/docs/kh_workflow_get.md
@@ -25,7 +25,7 @@ kh workflow get <workflow-id> [flags]
 ### Options inherited from parent commands
 
 ```
-  -H, --host string   KeeperHub host (default: app.keeperhub.io)
+  -H, --host string   KeeperHub host (default: app.keeperhub.com)
       --jq string     Filter JSON output with a jq expression
       --json          Output as JSON
       --no-color      Disable color output

--- a/docs/kh_workflow_go-live.md
+++ b/docs/kh_workflow_go-live.md
@@ -27,7 +27,7 @@ kh workflow go-live <workflow-id> [flags]
 ### Options inherited from parent commands
 
 ```
-  -H, --host string   KeeperHub host (default: app.keeperhub.io)
+  -H, --host string   KeeperHub host (default: app.keeperhub.com)
       --jq string     Filter JSON output with a jq expression
       --json          Output as JSON
       --no-color      Disable color output

--- a/docs/kh_workflow_list.md
+++ b/docs/kh_workflow_list.md
@@ -26,7 +26,7 @@ kh workflow list [flags]
 ### Options inherited from parent commands
 
 ```
-  -H, --host string   KeeperHub host (default: app.keeperhub.io)
+  -H, --host string   KeeperHub host (default: app.keeperhub.com)
       --jq string     Filter JSON output with a jq expression
       --json          Output as JSON
       --no-color      Disable color output

--- a/docs/kh_workflow_pause.md
+++ b/docs/kh_workflow_pause.md
@@ -26,7 +26,7 @@ kh workflow pause <workflow-id> [flags]
 ### Options inherited from parent commands
 
 ```
-  -H, --host string   KeeperHub host (default: app.keeperhub.io)
+  -H, --host string   KeeperHub host (default: app.keeperhub.com)
       --jq string     Filter JSON output with a jq expression
       --json          Output as JSON
       --no-color      Disable color output

--- a/docs/kh_workflow_run.md
+++ b/docs/kh_workflow_run.md
@@ -35,7 +35,7 @@ kh workflow run <workflow-id> [flags]
 ### Options inherited from parent commands
 
 ```
-  -H, --host string   KeeperHub host (default: app.keeperhub.io)
+  -H, --host string   KeeperHub host (default: app.keeperhub.com)
       --jq string     Filter JSON output with a jq expression
       --json          Output as JSON
       --no-color      Disable color output

--- a/internal/auth/keyring_test.go
+++ b/internal/auth/keyring_test.go
@@ -32,10 +32,10 @@ func overrideKeyring(t *testing.T) {
 func TestSetGetToken(t *testing.T) {
 	overrideKeyring(t)
 
-	err := SetToken("app.keeperhub.io", "tok_abc123")
+	err := SetToken("app.keeperhub.com", "tok_abc123")
 	require.NoError(t, err)
 
-	got, err := GetToken("app.keeperhub.io")
+	got, err := GetToken("app.keeperhub.com")
 	require.NoError(t, err)
 	require.Equal(t, "tok_abc123", got)
 }
@@ -51,11 +51,11 @@ func TestGetToken_Missing(t *testing.T) {
 func TestDeleteToken(t *testing.T) {
 	overrideKeyring(t)
 
-	require.NoError(t, SetToken("app.keeperhub.io", "tok_xyz"))
+	require.NoError(t, SetToken("app.keeperhub.com", "tok_xyz"))
 
-	require.NoError(t, DeleteToken("app.keeperhub.io"))
+	require.NoError(t, DeleteToken("app.keeperhub.com"))
 
-	got, err := GetToken("app.keeperhub.io")
+	got, err := GetToken("app.keeperhub.com")
 	require.NoError(t, err)
 	require.Equal(t, "", got)
 }

--- a/internal/auth/oauth_test.go
+++ b/internal/auth/oauth_test.go
@@ -46,7 +46,7 @@ func TestBrowserLogin_CapturesToken(t *testing.T) {
 	errCh := make(chan error, 1)
 
 	go func() {
-		tok, err := BrowserLogin("app.keeperhub.io", ios)
+		tok, err := BrowserLogin("app.keeperhub.com", ios)
 		if err != nil {
 			errCh <- err
 			return
@@ -79,7 +79,7 @@ func TestBrowserLogin_CapturesToken(t *testing.T) {
 		t.Fatal("timed out waiting for BrowserLogin to return")
 	}
 
-	stored, err := GetToken("app.keeperhub.io")
+	stored, err := GetToken("app.keeperhub.com")
 	require.NoError(t, err)
 	require.Equal(t, "test_token_123", stored)
 }
@@ -92,7 +92,7 @@ func TestBrowserLogin_NoTokenInCallback(t *testing.T) {
 
 	errCh := make(chan error, 1)
 	go func() {
-		_, err := BrowserLogin("app.keeperhub.io", ios)
+		_, err := BrowserLogin("app.keeperhub.com", ios)
 		errCh <- err
 	}()
 

--- a/internal/auth/resolver_test.go
+++ b/internal/auth/resolver_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const testHost = "app.keeperhub.io"
+const testHost = "app.keeperhub.com"
 
 func setupEmptyKeyring(t *testing.T) {
 	t.Helper()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,7 +19,7 @@ type Config struct {
 func DefaultConfig() Config {
 	return Config{
 		ConfigVersion: "1",
-		DefaultHost:   "app.keeperhub.io",
+		DefaultHost:   "app.keeperhub.com",
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -13,8 +13,8 @@ func TestDefaultConfig(t *testing.T) {
 	if cfg.ConfigVersion != "1" {
 		t.Errorf("ConfigVersion: got %q, want %q", cfg.ConfigVersion, "1")
 	}
-	if cfg.DefaultHost != "app.keeperhub.io" {
-		t.Errorf("DefaultHost: got %q, want %q", cfg.DefaultHost, "app.keeperhub.io")
+	if cfg.DefaultHost != "app.keeperhub.com" {
+		t.Errorf("DefaultHost: got %q, want %q", cfg.DefaultHost, "app.keeperhub.com")
 	}
 }
 

--- a/internal/config/hosts.go
+++ b/internal/config/hosts.go
@@ -9,7 +9,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-const defaultHost = "app.keeperhub.io"
+const defaultHost = "app.keeperhub.com"
 
 // HostConfig holds per-host authentication and connection details.
 type HostConfig struct {
@@ -65,7 +65,7 @@ func WriteHosts(cfg HostsConfig) error {
 }
 
 // ActiveHost resolves the active host using the priority chain:
-// flagHost > envHost > h.DefaultHost > config.yml DefaultHost > "app.keeperhub.io"
+// flagHost > envHost > h.DefaultHost > config.yml DefaultHost > "app.keeperhub.com"
 func (h *HostsConfig) ActiveHost(flagHost, envHost string) string {
 	if flagHost != "" {
 		return flagHost

--- a/internal/config/hosts_test.go
+++ b/internal/config/hosts_test.go
@@ -16,8 +16,8 @@ func TestActiveHostFallback(t *testing.T) {
 
 	h := config.HostsConfig{}
 	got := h.ActiveHost("", "")
-	if got != "app.keeperhub.io" {
-		t.Errorf("ActiveHost fallback: got %q, want %q", got, "app.keeperhub.io")
+	if got != "app.keeperhub.com" {
+		t.Errorf("ActiveHost fallback: got %q, want %q", got, "app.keeperhub.com")
 	}
 }
 
@@ -102,11 +102,11 @@ func TestReadHostsMissingFile(t *testing.T) {
 func TestHostEntryLookup(t *testing.T) {
 	h := config.HostsConfig{
 		Hosts: map[string]config.HostConfig{
-			"app.keeperhub.io": {User: "user@example.com"},
+			"app.keeperhub.com": {User: "user@example.com"},
 		},
 	}
 
-	entry, ok := h.HostEntry("app.keeperhub.io")
+	entry, ok := h.HostEntry("app.keeperhub.com")
 	if !ok {
 		t.Fatal("expected to find host entry")
 	}

--- a/internal/http/url_test.go
+++ b/internal/http/url_test.go
@@ -25,13 +25,13 @@ func TestBuildBaseURL(t *testing.T) {
 		},
 		{
 			name:  "https scheme preserved unchanged",
-			input: "https://app.keeperhub.io",
-			want:  "https://app.keeperhub.io",
+			input: "https://app.keeperhub.com",
+			want:  "https://app.keeperhub.com",
 		},
 		{
 			name:  "bare domain adds https scheme",
-			input: "app.keeperhub.io",
-			want:  "https://app.keeperhub.io",
+			input: "app.keeperhub.com",
+			want:  "https://app.keeperhub.com",
 		},
 		{
 			name:  "bare hostname trailing slash stripped",

--- a/tests/integration/auth_test.go
+++ b/tests/integration/auth_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const stagingHost = "app.keeperhub.io"
+const stagingHost = "app.keeperhub.com"
 
 // TestAuthLoginFlow verifies that a token can be resolved for the staging host.
 // Skips if KH_TEST_EMAIL and KH_TEST_PASSWORD are not set.


### PR DESCRIPTION
## Summary
- Production URL is `app.keeperhub.com`, not `app.keeperhub.io`
- Updates default host constant in `config.go` and `hosts.go`
- Updates all hardcoded fallbacks in command files (`doctor`, `run status/logs/cancel`)
- Updates help text, examples, and environment topic
- Updates all test assertions to match
- Regenerated all docs via `go run docs/generate.go`

## Test plan
- [x] `go test -race ./...` passes (all 29 packages)
- [x] Zero remaining `app.keeperhub.io` references in codebase
- [ ] After merge, `kh auth login` opens browser to `https://app.keeperhub.com/api/auth/sign-in/social?...`