### PR TITLE
fix: docs-sync workflow_dispatch trigger

### DIFF
--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -3,7 +3,7 @@ name: Sync CLI Docs to KeeperHub
 on:
   release:
     types: [published]
-  workflow_dispatch: {}
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
Remove empty braces from workflow_dispatch trigger. GitHub Actions does not recognize `workflow_dispatch: {}` as a valid trigger.