### PR TITLE
fix: reorder docs-sync triggers to fix workflow_dispatch

### DIFF
--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -1,9 +1,9 @@
 name: Sync CLI Docs to KeeperHub
 
 on:
+  workflow_dispatch:
   release:
     types: [published]
-  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
Move workflow_dispatch before release to force GitHub to re-register the dispatch trigger.