### PR TITLE
fix: set git identity in sync-cli-docs workflow

### DIFF
--- a/.github/workflows/sync-cli-docs.yml
+++ b/.github/workflows/sync-cli-docs.yml
@@ -99,6 +99,8 @@ jobs:
           RELEASE_TAG: ${{ github.event.release.tag_name || 'manual' }}
         run: |
           cd keeperhub
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
           # Sanitize tag for branch name
           SAFE_TAG=$(echo "$RELEASE_TAG" | sed 's/[^a-zA-Z0-9.-]/-/g')


### PR DESCRIPTION
## Summary
- The sync-cli-docs workflow checks out the KeeperHub repo fresh, which has no git config
- `git commit` fails with `Author identity unknown` on every run
- Adds `git config user.name/email` for `github-actions[bot]` before the commit step

## Test plan
- [ ] Merge and trigger workflow via `workflow_dispatch` or next release
- [ ] Verify the workflow completes successfully