### PR TITLE
fix: resolve --host flag in MCP serve mode

### DIFF
--- a/cmd/kh/main.go
+++ b/cmd/kh/main.go
@@ -20,27 +20,45 @@ func main() {
 	// rootCmd is created first so the HTTPClient closure can read --host after flag parsing.
 	var rootCmd *cobra.Command
 
+	// resolveActiveHost returns the effective host using the priority chain:
+	// --host flag > KH_HOST env > hosts.yml default > config.yml > built-in default.
+	resolveActiveHost := func() string {
+		var flagHost string
+		if rootCmd != nil {
+			if f := rootCmd.PersistentFlags().Lookup("host"); f != nil {
+				flagHost = f.Value.String()
+			}
+		}
+		envHost := os.Getenv("KH_HOST")
+		hosts, err := config.ReadHosts()
+		if err != nil {
+			if flagHost != "" {
+				return flagHost
+			}
+			if envHost != "" {
+				return envHost
+			}
+			return "app.keeperhub.com"
+		}
+		return hosts.ActiveHost(flagHost, envHost)
+	}
+
 	f := &cmdutil.Factory{
 		AppVersion: version.Version,
 		IOStreams:   ios,
 		Config: func() (config.Config, error) {
 			return config.ReadConfig()
 		},
+		BaseURL: func() string {
+			return khhttp.BuildBaseURL(resolveActiveHost())
+		},
 		HTTPClient: func() (*khhttp.Client, error) {
+			activeHost := resolveActiveHost()
+
 			hosts, err := config.ReadHosts()
 			if err != nil {
 				return nil, err
 			}
-
-			// Priority: --host flag > KH_HOST env > hosts.yml default > built-in default
-			var flagHost string
-			if rootCmd != nil {
-				if f := rootCmd.PersistentFlags().Lookup("host"); f != nil {
-					flagHost = f.Value.String()
-				}
-			}
-			envHost := os.Getenv("KH_HOST")
-			activeHost := hosts.ActiveHost(flagHost, envHost)
 
 			// Resolve token using the auth chain: KH_API_KEY > keyring > hosts.yml
 			resolved, err := auth.ResolveToken(activeHost)

--- a/cmd/serve/schemas.go
+++ b/cmd/serve/schemas.go
@@ -38,12 +38,7 @@ func fetchMCPSchemas(f *cmdutil.Factory) (*SchemasResponse, error) {
 		return nil, fmt.Errorf("creating HTTP client: %w", err)
 	}
 
-	cfg, err := f.Config()
-	if err != nil {
-		return nil, fmt.Errorf("reading config: %w", err)
-	}
-
-	url := khhttp.BuildBaseURL(cmdutil.ResolveHost(nil, cfg)) + "/api/mcp/schemas"
+	url := f.BaseURL() + "/api/mcp/schemas"
 	req, err := client.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return nil, fmt.Errorf("building request: %w", err)

--- a/cmd/serve/serve_test.go
+++ b/cmd/serve/serve_test.go
@@ -46,6 +46,7 @@ func newServeFactory(server *httptest.Server, ios *iostreams.IOStreams) *cmdutil
 		IOStreams:   ios,
 		HTTPClient: func() (*khhttp.Client, error) { return client, nil },
 		Config:     func() (config.Config, error) { return config.Config{DefaultHost: server.URL}, nil },
+		BaseURL:    func() string { return server.URL },
 	}
 }
 

--- a/cmd/serve/tools.go
+++ b/cmd/serve/tools.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"strings"
 
-	khhttp "github.com/keeperhub/cli/internal/http"
 	"github.com/keeperhub/cli/pkg/cmdutil"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
@@ -89,12 +88,7 @@ func MakeToolHandler(f *cmdutil.Factory, actionType string) mcp.ToolHandler {
 			return nil, fmt.Errorf("creating HTTP client: %w", err)
 		}
 
-		cfg, err := f.Config()
-		if err != nil {
-			return nil, fmt.Errorf("reading config: %w", err)
-		}
-
-		url := khhttp.BuildBaseURL(cmdutil.ResolveHost(nil, cfg)) + "/api/execute/" + actionType
+		url := f.BaseURL() + "/api/execute/" + actionType
 		httpReq, err := client.NewRequest(http.MethodPost, url, bytes.NewReader(bodyBytes))
 		if err != nil {
 			return nil, fmt.Errorf("building request: %w", err)
@@ -163,12 +157,7 @@ func makeStaticHandler(
 			return nil, fmt.Errorf("creating HTTP client: %w", err)
 		}
 
-		cfg, err := f.Config()
-		if err != nil {
-			return nil, fmt.Errorf("reading config: %w", err)
-		}
-
-		baseURL := khhttp.BuildBaseURL(cmdutil.ResolveHost(nil, cfg))
+		baseURL := f.BaseURL()
 		targetURL := buildURL(args, baseURL)
 
 		var body io.Reader

--- a/pkg/cmdutil/factory.go
+++ b/pkg/cmdutil/factory.go
@@ -20,6 +20,11 @@ type Factory struct {
 	// The client automatically injects version headers and per-host credentials.
 	HTTPClient func() (*khhttp.Client, error)
 
+	// BaseURL returns the resolved base URL for API requests, accounting for
+	// --host flag, KH_HOST env, and config defaults. Use this instead of
+	// ResolveHost when a cobra.Command is not available (e.g. MCP serve mode).
+	BaseURL func() string
+
 	// IOStreams provides the standard input/output streams.
 	IOStreams *iostreams.IOStreams
 }


### PR DESCRIPTION
## Summary
- MCP serve mode (`kh serve --mcp --host <url>`) ignored the `--host` flag for API requests. `tools.go` and `schemas.go` called `ResolveHost(nil, cfg)` with a nil cobra command, so the flag was invisible and all URLs resolved to the default prod host.
- Add `BaseURL func() string` to Factory using the same priority chain as HTTPClient (flag > env > config > default). Replace inline `ResolveHost` calls in serve mode with `f.BaseURL()`.

## Changes
- `pkg/cmdutil/factory.go` -- add `BaseURL` field
- `cmd/kh/main.go` -- extract `resolveActiveHost()` helper, wire `BaseURL` using same priority chain
- `cmd/serve/tools.go` -- replace `ResolveHost(nil, cfg)` with `f.BaseURL()`
- `cmd/serve/schemas.go` -- same
- `cmd/serve/serve_test.go` -- wire `BaseURL` in test factory

## Test plan
- [x] All 29 Go test packages pass
- [x] Manually verified: `kh serve --mcp --host http://localhost:3000` returns real data from local dev
- [x] Manually verified: `kh serve --mcp --host https://app-staging.keeperhub.com` returns real data from staging (with CF headers)
- [x] Full MCP CRUD + execute tested on all 3 envs (dev, staging, prod)
- [x] All CLI commands tested on all 3 envs (workflow list/create/get/update/delete/run)