### PR TITLE
fix: update docs sync target from techops-services to KeeperHub org

### DIFF
--- a/.github/workflows/sync-cli-docs.yml
+++ b/.github/workflows/sync-cli-docs.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Checkout KeeperHub repo
         uses: actions/checkout@v4
         with:
-          repository: techops-services/keeperhub
+          repository: KeeperHub/keeperhub
           token: ${{ secrets.KEEPERHUB_PAT }}
           path: keeperhub
           ref: staging


### PR DESCRIPTION
## Summary

- sync-cli-docs.yml was checking out `techops-services/keeperhub` instead of `KeeperHub/keeperhub`

## Action needed after merge

Verify `KEEPERHUB_PAT` and `HOMEBREW_TAP_TOKEN` secrets have access to the KeeperHub org:
- If fine-grained PATs scoped to `techops-services`, regenerate scoped to `KeeperHub`
- If classic PATs owned by a KeeperHub org member, they likely already work

## Test plan

- [ ] Trigger sync-cli-docs workflow manually after merge
- [ ] Verify PR is created in KeeperHub/keeperhub (not techops-services/keeperhub)