### PR TITLE
feat(KEEP-143): add exec, proto, tpl command aliases

### DIFF
--- a/cmd/execute/execute.go
+++ b/cmd/execute/execute.go
@@ -9,7 +9,7 @@ func NewExecuteCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "execute",
 		Short:   "Execute direct blockchain actions",
-		Aliases: []string{"ex"},
+		Aliases: []string{"ex", "exec"},
 		Long: `Execute blockchain operations directly without building a full workflow.
 Supports token transfers and smart contract calls. Returns execution IDs
 immediately; use --wait to block until completion.

--- a/cmd/protocol/protocol.go
+++ b/cmd/protocol/protocol.go
@@ -9,7 +9,7 @@ func NewProtocolCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "protocol",
 		Short:   "Browse blockchain protocols",
-		Aliases: []string{"pr"},
+		Aliases: []string{"pr", "proto"},
 		Example: `  # List all protocols
   kh pr ls
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -178,7 +178,7 @@ func TestRootCmdHelpDoesNotIncludeAPIKey(t *testing.T) {
 }
 
 func TestAllNounAliasesResolve(t *testing.T) {
-	aliases := []string{"wf", "r", "ex", "p", "t", "o", "a", "pr", "w", "tp", "b", "doc", "v"}
+	aliases := []string{"wf", "r", "ex", "exec", "p", "t", "o", "a", "pr", "proto", "w", "tp", "tpl", "b", "doc", "v"}
 
 	for _, alias := range aliases {
 		t.Run(alias, func(t *testing.T) {

--- a/cmd/template/template.go
+++ b/cmd/template/template.go
@@ -9,7 +9,7 @@ func NewTemplateCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "template",
 		Short:   "Manage workflow templates",
-		Aliases: []string{"tp"},
+		Aliases: []string{"tp", "tpl"},
 		Example: `  # List available templates
   kh tp ls
 

--- a/cmd/workflow/run.go
+++ b/cmd/workflow/run.go
@@ -39,7 +39,7 @@ func NewRunCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "run <workflow-id>",
 		Short:   "Run a workflow",
-		Aliases: []string{"r"},
+		Aliases: []string{"r", "exec"},
 		Args:    cobra.ExactArgs(1),
 		Long: `Run triggers a workflow execution. By default the command returns the
 execution ID immediately. Use --wait to block until the run completes


### PR DESCRIPTION
## Summary

- Adds `exec` alias to `execute` command (alongside existing `ex`)
- Adds `proto` alias to `protocol` command (alongside existing `pr`)
- Adds `tpl` alias to `template` command (alongside existing `tp`)
- Adds `exec` alias to `workflow run` subcommand (alongside existing `r`)
- Updates `TestAllNounAliasesResolve` to cover the new top-level aliases

Note: `workflow` already had `wf` and `workflow list` already had `ls`, so no changes needed there.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./... -count=1` all tests pass, including updated alias resolution test