### PR TITLE
feat: KEEP-438 add Cloudflare Access header support

### DIFF
--- a/cmd/doctor/doctor.go
+++ b/cmd/doctor/doctor.go
@@ -139,11 +139,15 @@ func getHost(f *cmdutil.Factory) (string, error) {
 
 // doGet performs a GET request against url with the given context, returning
 // the response. The caller is responsible for closing resp.Body.
-func doGet(ctx context.Context, client *http.Client, url string) (*http.Response, error) {
+//
+// host is used to look up per-host headers (hosts.yml + Cloudflare Access env)
+// so doctor can reach environments behind CF Access.
+func doGet(ctx context.Context, client *http.Client, host, url string) (*http.Response, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
 	}
+	khhttp.ApplyHostHeaders(req, host)
 	return client.Do(req)
 }
 
@@ -168,7 +172,7 @@ func checkAuth(ctx context.Context, f *cmdutil.Factory) CheckResult {
 	}
 
 	url := khhttp.BuildBaseURL(host) + "/api/auth/get-session"
-	resp, err := doGet(ctx, client, url)
+	resp, err := doGet(ctx, client, host, url)
 	if err != nil {
 		if isContextTimeout(err) {
 			return CheckResult{Status: "warn", Message: "auth check timed out"}
@@ -202,7 +206,7 @@ func checkAPI(ctx context.Context, f *cmdutil.Factory) CheckResult {
 
 	url := khhttp.BuildBaseURL(host) + "/api/health"
 	start := time.Now()
-	resp, err := doGet(ctx, client, url)
+	resp, err := doGet(ctx, client, host, url)
 	latency := time.Since(start)
 
 	if err != nil {
@@ -234,7 +238,7 @@ func checkWallet(ctx context.Context, f *cmdutil.Factory) CheckResult {
 	}
 
 	url := khhttp.BuildBaseURL(host) + "/api/user/wallet/balances"
-	resp, err := doGet(ctx, client, url)
+	resp, err := doGet(ctx, client, host, url)
 	if err != nil {
 		if isContextTimeout(err) {
 			return CheckResult{Status: "warn", Message: "wallet check timed out"}
@@ -277,7 +281,7 @@ func checkSpendCap(ctx context.Context, f *cmdutil.Factory) CheckResult {
 	}
 
 	url := khhttp.BuildBaseURL(host) + "/api/billing/subscription"
-	resp, err := doGet(ctx, client, url)
+	resp, err := doGet(ctx, client, host, url)
 	if err != nil {
 		if isContextTimeout(err) {
 			return CheckResult{Status: "warn", Message: "spend cap check timed out"}
@@ -329,7 +333,7 @@ func checkChains(ctx context.Context, f *cmdutil.Factory) CheckResult {
 	}
 
 	url := khhttp.BuildBaseURL(host) + "/api/chains"
-	resp, err := doGet(ctx, client, url)
+	resp, err := doGet(ctx, client, host, url)
 	if err != nil {
 		if isContextTimeout(err) {
 			return CheckResult{Status: "fail", Message: "could not reach chain service (timeout after 5s)"}

--- a/cmd/kh/main.go
+++ b/cmd/kh/main.go
@@ -88,7 +88,7 @@ func main() {
 			return khhttp.NewClient(khhttp.ClientOptions{
 				Host:        activeHost,
 				Token:       resolved.Token,
-				Headers:     entry.Headers,
+				Headers:     khhttp.MergeCloudflareAccessEnv(entry.Headers),
 				OrgOverride: resolveOrgFlag(),
 				IOStreams:    ios,
 				AppVersion:  version.Version,

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -26,6 +26,26 @@ Run `kh auth login` to authenticate via browser OAuth. For headless environments
 
 Run `kh auth status` to see which method is active and whether your token is valid.
 
+## Gated Environments (Cloudflare Access)
+
+Hosts behind Cloudflare Access (PR previews, staging) require additional credentials on every request. The CLI sends them as headers from two sources:
+
+1. **Environment variables** (precedence: env > hosts.yml):
+   - `CF_ACCESS_CLIENT_ID` + `CF_ACCESS_CLIENT_SECRET` -- service-token pair, sent as `CF-Access-Client-Id` / `CF-Access-Client-Secret`. Both must be set; partial values are ignored.
+   - `CF_AUTHORIZATION` -- the `cf_authorization` JWT minted by `cloudflared access login`, sent as `Cookie: CF_Authorization=<value>`.
+2. **Per-host `headers:` map in `hosts.yml`** -- arbitrary headers attached to every request to that host:
+
+   ```yaml
+   hosts:
+     app-pr-1234.keeperhub.com:
+       token: kh_prte_...
+       headers:
+         CF-Access-Client-Id: <id>
+         CF-Access-Client-Secret: <secret>
+   ```
+
+Use env vars in CI; use `hosts.yml` for stable per-environment config that follows your machine.
+
 ## Output Formats
 
 By default, most commands render a human-readable table. Use these flags for machine-readable output:

--- a/internal/auth/token.go
+++ b/internal/auth/token.go
@@ -80,6 +80,7 @@ func fetchSessionInfo(host, token string) (TokenInfo, error) {
 		return TokenInfo{}, fmt.Errorf("creating session request: %w", err)
 	}
 	req.Header.Set("Authorization", "Bearer "+token)
+	khhttp.ApplyHostHeaders(req, host)
 
 	resp, err := client.Do(req)
 	if err != nil {
@@ -142,6 +143,7 @@ func fetchAPIKeyInfo(host, token string) (TokenInfo, error) {
 		return TokenInfo{}, fmt.Errorf("creating validation request: %w", err)
 	}
 	req.Header.Set("Authorization", "Bearer "+token)
+	khhttp.ApplyHostHeaders(req, host)
 
 	resp, err := client.Do(req)
 	if err != nil {
@@ -175,6 +177,7 @@ func fetchOrgDetails(client *http.Client, host, token, orgID string) (string, st
 		return "", ""
 	}
 	req.Header.Set("Authorization", "Bearer "+token)
+	khhttp.ApplyHostHeaders(req, host)
 
 	resp, err := client.Do(req)
 	if err != nil || resp.StatusCode != http.StatusOK {

--- a/internal/http/cfaccess.go
+++ b/internal/http/cfaccess.go
@@ -41,7 +41,12 @@ func MergeCloudflareAccessEnv(base map[string]string) map[string]string {
 		out["CF-Access-Client-Secret"] = secret
 	}
 	if cookie != "" {
-		out["Cookie"] = "CF_Authorization=" + cookie
+		pair := "CF_Authorization=" + cookie
+		if existing, ok := out["Cookie"]; ok && existing != "" {
+			out["Cookie"] = existing + "; " + pair
+		} else {
+			out["Cookie"] = pair
+		}
 	}
 	return out
 }

--- a/internal/http/cfaccess.go
+++ b/internal/http/cfaccess.go
@@ -1,0 +1,67 @@
+package khhttp
+
+import (
+	"net/http"
+	"os"
+
+	"github.com/keeperhub/cli/internal/config"
+)
+
+// Cloudflare Access env vars. CF_ACCESS_CLIENT_ID + CF_ACCESS_CLIENT_SECRET
+// is the service-token pair used by CI; CF_AUTHORIZATION carries the
+// cf_authorization JWT minted by `cloudflared access login` for interactive
+// devs. Both are sent when set; CF Access accepts either.
+const (
+	envCFAccessClientID     = "CF_ACCESS_CLIENT_ID"
+	envCFAccessClientSecret = "CF_ACCESS_CLIENT_SECRET"
+	envCFAuthorization      = "CF_AUTHORIZATION"
+)
+
+// MergeCloudflareAccessEnv returns base with Cloudflare Access headers added
+// from the environment. Env values take precedence over base entries with the
+// same key (matching the KH_API_KEY > hosts.yml precedence used elsewhere).
+//
+// Service-token headers are only added when both ID and secret are set, to
+// avoid sending half a credential pair.
+func MergeCloudflareAccessEnv(base map[string]string) map[string]string {
+	id := os.Getenv(envCFAccessClientID)
+	secret := os.Getenv(envCFAccessClientSecret)
+	cookie := os.Getenv(envCFAuthorization)
+
+	if id == "" && secret == "" && cookie == "" {
+		return base
+	}
+
+	out := make(map[string]string, len(base)+3)
+	for k, v := range base {
+		out[k] = v
+	}
+	if id != "" && secret != "" {
+		out["CF-Access-Client-Id"] = id
+		out["CF-Access-Client-Secret"] = secret
+	}
+	if cookie != "" {
+		out["Cookie"] = "CF_Authorization=" + cookie
+	}
+	return out
+}
+
+// HeadersForHost returns the set of headers to apply to a request targeting
+// host: per-host entries from hosts.yml with Cloudflare Access env vars merged
+// on top. Used by code paths that build their own *http.Client and bypass the
+// shared khhttp.Client (auth token validation, doctor checks).
+func HeadersForHost(host string) map[string]string {
+	hosts, err := config.ReadHosts()
+	if err != nil {
+		return MergeCloudflareAccessEnv(nil)
+	}
+	entry, _ := hosts.HostEntry(host)
+	return MergeCloudflareAccessEnv(entry.Headers)
+}
+
+// ApplyHostHeaders sets per-host headers (hosts.yml + CF env) on req.
+func ApplyHostHeaders(req *http.Request, host string) {
+	for k, v := range HeadersForHost(host) {
+		req.Header.Set(k, v)
+	}
+}

--- a/internal/http/cfaccess_test.go
+++ b/internal/http/cfaccess_test.go
@@ -1,0 +1,81 @@
+package khhttp_test
+
+import (
+	"testing"
+
+	khhttp "github.com/keeperhub/cli/internal/http"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMergeCloudflareAccessEnv_NoEnv(t *testing.T) {
+	t.Setenv("CF_ACCESS_CLIENT_ID", "")
+	t.Setenv("CF_ACCESS_CLIENT_SECRET", "")
+	t.Setenv("CF_AUTHORIZATION", "")
+
+	base := map[string]string{"X-Existing": "v"}
+	out := khhttp.MergeCloudflareAccessEnv(base)
+
+	assert.Equal(t, base, out, "with no env vars, base should pass through unchanged")
+}
+
+func TestMergeCloudflareAccessEnv_ServiceToken(t *testing.T) {
+	t.Setenv("CF_ACCESS_CLIENT_ID", "id-123")
+	t.Setenv("CF_ACCESS_CLIENT_SECRET", "secret-abc")
+	t.Setenv("CF_AUTHORIZATION", "")
+
+	out := khhttp.MergeCloudflareAccessEnv(nil)
+
+	assert.Equal(t, "id-123", out["CF-Access-Client-Id"])
+	assert.Equal(t, "secret-abc", out["CF-Access-Client-Secret"])
+	assert.NotContains(t, out, "Cookie")
+}
+
+func TestMergeCloudflareAccessEnv_PartialServiceTokenIgnored(t *testing.T) {
+	// Only ID set, no secret -> nothing added (would 403 anyway and is misleading).
+	t.Setenv("CF_ACCESS_CLIENT_ID", "id-only")
+	t.Setenv("CF_ACCESS_CLIENT_SECRET", "")
+	t.Setenv("CF_AUTHORIZATION", "")
+
+	out := khhttp.MergeCloudflareAccessEnv(nil)
+
+	assert.NotContains(t, out, "CF-Access-Client-Id")
+	assert.NotContains(t, out, "CF-Access-Client-Secret")
+}
+
+func TestMergeCloudflareAccessEnv_Cookie(t *testing.T) {
+	t.Setenv("CF_ACCESS_CLIENT_ID", "")
+	t.Setenv("CF_ACCESS_CLIENT_SECRET", "")
+	t.Setenv("CF_AUTHORIZATION", "jwt-token")
+
+	out := khhttp.MergeCloudflareAccessEnv(nil)
+
+	assert.Equal(t, "CF_Authorization=jwt-token", out["Cookie"])
+}
+
+func TestMergeCloudflareAccessEnv_EnvWinsOverBase(t *testing.T) {
+	t.Setenv("CF_ACCESS_CLIENT_ID", "env-id")
+	t.Setenv("CF_ACCESS_CLIENT_SECRET", "env-secret")
+	t.Setenv("CF_AUTHORIZATION", "")
+
+	base := map[string]string{
+		"CF-Access-Client-Id":     "yaml-id",
+		"CF-Access-Client-Secret": "yaml-secret",
+		"X-Other":                 "preserved",
+	}
+	out := khhttp.MergeCloudflareAccessEnv(base)
+
+	assert.Equal(t, "env-id", out["CF-Access-Client-Id"])
+	assert.Equal(t, "env-secret", out["CF-Access-Client-Secret"])
+	assert.Equal(t, "preserved", out["X-Other"])
+}
+
+func TestMergeCloudflareAccessEnv_DoesNotMutateBase(t *testing.T) {
+	t.Setenv("CF_ACCESS_CLIENT_ID", "id")
+	t.Setenv("CF_ACCESS_CLIENT_SECRET", "secret")
+	t.Setenv("CF_AUTHORIZATION", "")
+
+	base := map[string]string{"K": "v"}
+	_ = khhttp.MergeCloudflareAccessEnv(base)
+
+	assert.Equal(t, map[string]string{"K": "v"}, base, "base map should not be mutated")
+}

--- a/internal/http/cfaccess_test.go
+++ b/internal/http/cfaccess_test.go
@@ -69,6 +69,30 @@ func TestMergeCloudflareAccessEnv_EnvWinsOverBase(t *testing.T) {
 	assert.Equal(t, "preserved", out["X-Other"])
 }
 
+func TestMergeCloudflareAccessEnv_CookieAppendsToExisting(t *testing.T) {
+	t.Setenv("CF_ACCESS_CLIENT_ID", "")
+	t.Setenv("CF_ACCESS_CLIENT_SECRET", "")
+	t.Setenv("CF_AUTHORIZATION", "jwt-token")
+
+	base := map[string]string{"Cookie": "session=abc"}
+	out := khhttp.MergeCloudflareAccessEnv(base)
+
+	assert.Equal(t, "session=abc; CF_Authorization=jwt-token", out["Cookie"],
+		"existing Cookie value should be preserved and CF_Authorization appended")
+}
+
+func TestMergeCloudflareAccessEnv_ServiceTokenAndCookieCombined(t *testing.T) {
+	t.Setenv("CF_ACCESS_CLIENT_ID", "id-1")
+	t.Setenv("CF_ACCESS_CLIENT_SECRET", "secret-1")
+	t.Setenv("CF_AUTHORIZATION", "jwt-1")
+
+	out := khhttp.MergeCloudflareAccessEnv(nil)
+
+	assert.Equal(t, "id-1", out["CF-Access-Client-Id"])
+	assert.Equal(t, "secret-1", out["CF-Access-Client-Secret"])
+	assert.Equal(t, "CF_Authorization=jwt-1", out["Cookie"])
+}
+
 func TestMergeCloudflareAccessEnv_DoesNotMutateBase(t *testing.T) {
 	t.Setenv("CF_ACCESS_CLIENT_ID", "id")
 	t.Setenv("CF_ACCESS_CLIENT_SECRET", "secret")


### PR DESCRIPTION
## Summary

- Adds Cloudflare Access env-var pass-through so `kh` can talk to PR previews (`app-pr-<N>.keeperhub.com`) and staging behind Cloudflare Zero Trust.
- Reads `CF_ACCESS_CLIENT_ID` + `CF_ACCESS_CLIENT_SECRET` (service-token pair, sent as `CF-Access-Client-Id` / `CF-Access-Client-Secret`) and `CF_AUTHORIZATION` (cookie minted by `cloudflared access login`, sent as `Cookie: CF_Authorization=...`). Env wins over `hosts.yml`, matching the existing `KH_API_KEY > hosts.yml` precedence.
- Fixes three call paths that built their own `*http.Client` and bypassed the shared `khhttp.Client` header injection: `internal/auth/token.go` (`fetchSessionInfo`, `fetchAPIKeyInfo`, `fetchOrgDetails`) and `cmd/doctor/doctor.go`. Without this, `kh auth status` and `kh doctor` would 403 at CF Access even with creds configured.
- Cookie merge appends to any existing `Cookie:` value in `hosts.yml.headers` (RFC 6265 `; ` separator) instead of clobbering it.

## Notes

- The per-host `headers:` map in `hosts.yml` already supported arbitrary headers via the shared client. This PR is just the env-var convenience layer plus the bypass-path fixes.
- `internal/auth/device.go` (browser login flow) loops over `hosts.yml` headers but does not pick up env vars. Left as follow-up since service tokens are CI-only and the affected envs are reached with API keys, not the device flow.
- The pre-existing API-key validator in `fetchAPIKeyInfo` accepts any HTTP 200 (so a CF Access HTML login page falsely validates). Independent issue, flagged but not fixed here.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` passes (unit tests for `MergeCloudflareAccessEnv` cover no-env / service-token / partial-creds-ignored / cookie / cookie-appends-to-existing / env-precedence / service-token+cookie combined / no-mutation)
- [x] End-to-end against `app-staging.keeperhub.com` with a real `CF_AUTHORIZATION` cookie:
  - Without env: `kh chain list` -> `decoding chains response: invalid character '<'` (request lands on the CF Access HTML login page)
  - With env: real chain table returned
- [x] `kh doctor` against the same host: chains check goes from "reachable" (HTML 200) to "19 chains available" (real JSON) once cookie is set
- [x] End-to-end against `app-pr-1162.keeperhub.com` using `hosts.yml` only (no env): `kh chain list`, `kh workflow list`, `kh workflow create`, `kh workflow get`, `kh auth status`, `kh doctor` all working through CF Access

## Usage

### One-time setup per gated environment

Either path works; pick one.

**A) `hosts.yml` (recommended for everyday work)**

```yaml
# ~/.config/kh/hosts.yml
hosts:
    app-pr-1234.keeperhub.com:
        token: kh_<api-key-from-the-PR-env-UI>
        headers:
            CF-Access-Client-Id: <id>.access
            CF-Access-Client-Secret: <secret>
            # OR (for user-JWT auth via cloudflared):
            # Cookie: CF_Authorization=<jwt>
```

Then just run `kh --host app-pr-1234.keeperhub.com workflow list` (or `export KH_HOST=app-pr-1234.keeperhub.com`).

**B) Environment variables (recommended for CI / one-offs)**

```bash
# Service-token pair (both must be set; partial values ignored)
export CF_ACCESS_CLIENT_ID=<id>.access
export CF_ACCESS_CLIENT_SECRET=<secret>

# OR a cookie from cloudflared
export CF_AUTHORIZATION=$(cloudflared access token --app=https://app-pr-1234.keeperhub.com)

kh --host app-pr-1234.keeperhub.com workflow list
```

Env vars override `hosts.yml` on key collision; non-CF headers in `hosts.yml` are preserved.

### Cookie auth via `cloudflared` (when service tokens aren't authorized for the env)

```bash
# One-time, opens a browser tab; JWT is cached at ~/.cloudflared/<host>-<aud>-token (24h validity)
cloudflared access login https://app-pr-1234.keeperhub.com

# Read the cached JWT into env or hosts.yml
CF_AUTHORIZATION=$(cloudflared access token --app=https://app-pr-1234.keeperhub.com) kh ...
```

When `kh` against the env starts returning `invalid character '<'` (response is the CF Access HTML login page), the JWT has expired - re-run `cloudflared access login`.

### Precedence

Same model as `KH_API_KEY > hosts.yml`:

1. Env vars (`CF_ACCESS_CLIENT_ID` / `CF_ACCESS_CLIENT_SECRET`, `CF_AUTHORIZATION`) win on key collision.
2. `hosts.yml` `headers:` entries that don't collide are preserved.
3. `Authorization: Bearer <kh_token>` is set independently via `token:` / `KH_API_KEY` and is never overwritten by header merging.

### Caveats

- A service token must be authorized by **the specific app's** CF Access policy; a token scoped only to production will be rejected (`service_token_status: false` in the redirect JWT meta) by per-PR CF Access apps even though the headers reach CF.
- `cloudflared access token` returns the cached JWT unconditionally and does not auto-refresh; once expired, you must re-run `access login`.
- `Cookie` env merge appends to any existing `Cookie:` in `hosts.yml.headers` rather than overwriting, so users mixing CF auth with other cookies don't lose them.
