### PR TITLE
feat: add `kh w feedback` thin wrapper

### DIFF
--- a/cmd/wallet/feedback.go
+++ b/cmd/wallet/feedback.go
@@ -1,0 +1,67 @@
+package wallet
+
+import (
+	"github.com/keeperhub/cli/pkg/cmdutil"
+	"github.com/spf13/cobra"
+)
+
+// NewFeedbackCmd returns the `kh wallet feedback` subcommand -- a thin wrapper
+// around `npx @keeperhub/wallet feedback` that submits ERC-8004 ReputationRegistry
+// feedback for a workflow execution this wallet paid for.
+//
+// Signing + broadcast happens server-side in the npm package; the wallet's
+// Turnkey policy gates what can be signed (only giveFeedback() on the
+// ReputationRegistry on Ethereum mainnet). Caller wallet pays gas natively.
+func NewFeedbackCmd(f *cmdutil.Factory) *cobra.Command {
+	var (
+		executionID string
+		value       string
+		decimals    string
+		comment     string
+		agentID     string
+		chainID     string
+	)
+	cmd := &cobra.Command{
+		Use:   "feedback",
+		Short: "Submit ERC-8004 feedback for a workflow execution this wallet paid for",
+		Long: `Submit ERC-8004 ReputationRegistry feedback for a workflow execution this
+wallet paid for. Signs giveFeedback() via Turnkey and broadcasts on Ethereum
+mainnet via the KeeperHub server proxy. Caller wallet pays gas natively
+(~$0.05-2 per call at typical mainnet gas).
+
+Thin wrapper around ` + "`npx @keeperhub/wallet feedback`" + `. Defaults to rating
+KeeperHub's own ERC-8004 agent (id 31875 on Ethereum); use --agent-id to rate
+any other agent.`,
+		Example: `  # 5-star rating for an execution this wallet paid for
+  kh w feedback --execution-id c5ybokpmwxi7kiau5wxja --value 5
+
+  # 4.5-star rating with a comment
+  kh w feedback --execution-id c5ybokpmwxi7kiau5wxja --value 45 --decimals 1 --comment "very helpful"`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			args := []string{"--execution-id", executionID, "--value", value}
+			if decimals != "" {
+				args = append(args, "--decimals", decimals)
+			}
+			if comment != "" {
+				args = append(args, "--comment", comment)
+			}
+			if agentID != "" {
+				args = append(args, "--agent-id", agentID)
+			}
+			if chainID != "" {
+				args = append(args, "--chain-id", chainID)
+			}
+			return runNpxWallet(f, cmd, "feedback", args)
+		},
+	}
+	cmd.Flags().StringVar(&executionID, "execution-id", "", "workflow execution id (from a previous call_workflow response) (required)")
+	cmd.Flags().StringVar(&value, "value", "", "raw int128 rating value, e.g. 5 with --decimals 0 for a 5-star rating (required)")
+	cmd.Flags().StringVar(&decimals, "decimals", "", "decimals for value (0..18); 0 for integer scores, 1 for 0.1-step (default 0)")
+	cmd.Flags().StringVar(&comment, "comment", "", "optional plaintext comment included in the feedbackURI JSON")
+	cmd.Flags().StringVar(&agentID, "agent-id", "", "rated agent NFT id (uint256 decimal); defaults to KeeperHub agent 31875")
+	cmd.Flags().StringVar(&chainID, "chain-id", "", "agent chain id; defaults to 1 (Ethereum mainnet)")
+	_ = cmd.MarkFlagRequired("execution-id")
+	_ = cmd.MarkFlagRequired("value")
+	return cmd
+}

--- a/cmd/wallet/wallet.go
+++ b/cmd/wallet/wallet.go
@@ -20,7 +20,8 @@ Agentic wallet (thin wrappers around npx @keeperhub/wallet):
   kh w add        provision a new agentic wallet (no account required)
   kh w info       print agentic subOrgId + walletAddress
   kh w fund       print Coinbase Onramp URL + Tempo deposit address
-  kh w link       link agentic wallet to a KeeperHub account (needs KH_SESSION_COOKIE)`,
+  kh w link       link agentic wallet to a KeeperHub account (needs KH_SESSION_COOKIE)
+  kh w feedback   submit ERC-8004 feedback for a workflow execution this wallet paid for`,
 		Example: `  # Creator wallet balance (REST):
   kh w balance
 
@@ -43,6 +44,7 @@ Agentic wallet (thin wrappers around npx @keeperhub/wallet):
 	cmd.AddCommand(NewInfoCmd(f))
 	cmd.AddCommand(NewFundCmd(f))
 	cmd.AddCommand(NewLinkCmd(f))
+	cmd.AddCommand(NewFeedbackCmd(f))
 
 	return cmd
 }


### PR DESCRIPTION
## Summary

- Mirrors the new \`feedback\` subcommand in [@keeperhub/wallet](https://github.com/KeeperHub/agentic-wallet/pull/32) so users can submit ERC-8004 ReputationRegistry feedback for a workflow execution they paid for without dropping out of the \`kh\` CLI shell.
- Closes the user-facing loop alongside the keeperhub backend ([PR #1160 merged](https://github.com/KeeperHub/keeperhub/pull/1160)) and the agentic-wallet npm change. Validated end-to-end on Ethereum mainnet against KeeperHub's ERC-8004 agent (id 31875): tx [\`0xd8391d...3e92\`](https://etherscan.io/tx/0xd8391dcc4d74283533e344f2428f25bfd2b7ed4170d2ffb2df4681770bc13e92) confirmed in block 25041073.

## Usage

\`\`\`bash
# 5-star rating for an execution this wallet paid for
kh w feedback --execution-id c5ybokpmwxi7kiau5wxja --value 5

# 4.5-star rating with a comment
kh w feedback --execution-id c5ybokpmwxi7kiau5wxja --value 45 --decimals 1 \\
  --comment "very helpful"

# Rate a different agent
kh w feedback --execution-id <id> --value 5 --agent-id 12345
\`\`\`

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./cmd/wallet/...\` clean (existing wallet test suite passes)
- [ ] Pin to the agentic-wallet release that ships the upstream \`feedback\` subcommand once published (release-please will minor-bump from #32)

## Notes

Same wrapper pattern as \`kh w add\` / \`info\` / \`fund\` / \`link\`: forwards to \`npx @keeperhub/wallet feedback <flags>\` via stdlib \`os/exec\`. The flag layer here is dumb pass-through -- no payload parsing happens in Go because the npm package is the canonical signing layer. If the upstream subcommand grows new flags, only the dumb forwarding here needs an update.