### PR TITLE
chore: remove Cloudflare Access section from public docs

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -26,26 +26,6 @@ Run `kh auth login` to authenticate via browser OAuth. For headless environments
 
 Run `kh auth status` to see which method is active and whether your token is valid.
 
-## Gated Environments (Cloudflare Access)
-
-Hosts behind Cloudflare Access (PR previews, staging) require additional credentials on every request. The CLI sends them as headers from two sources:
-
-1. **Environment variables** (precedence: env > hosts.yml):
-   - `CF_ACCESS_CLIENT_ID` + `CF_ACCESS_CLIENT_SECRET` -- service-token pair, sent as `CF-Access-Client-Id` / `CF-Access-Client-Secret`. Both must be set; partial values are ignored.
-   - `CF_AUTHORIZATION` -- the `cf_authorization` JWT minted by `cloudflared access login`, sent as `Cookie: CF_Authorization=<value>`.
-2. **Per-host `headers:` map in `hosts.yml`** -- arbitrary headers attached to every request to that host:
-
-   ```yaml
-   hosts:
-     app-pr-1234.keeperhub.com:
-       token: kh_prte_...
-       headers:
-         CF-Access-Client-Id: <id>
-         CF-Access-Client-Secret: <secret>
-   ```
-
-Use env vars in CI; use `hosts.yml` for stable per-environment config that follows your machine.
-
 ## Output Formats
 
 By default, most commands render a human-readable table. Use these flags for machine-readable output:


### PR DESCRIPTION
## Summary

- Removes the "Gated Environments (Cloudflare Access)" section from \`docs/concepts.md\`.
- Documentation-only change: no Go code, tests, or behavior touched.
- The CF Access feature continues to work — \`CF_ACCESS_CLIENT_ID\`/\`CF_ACCESS_CLIENT_SECRET\`, \`CF_AUTHORIZATION\`, and per-host \`hosts.yml\` \`headers:\` maps still flow through \`internal/http/cfaccess.go\` and the shared HTTP client.
- Rationale: the public-facing CLI guide should not advertise the Cloudflare gating mechanism that fronts our environments.

## Test plan

- [x] \`grep\` confirms no remaining CF / Cloudflare / \`CF_ACCESS\` / \`cloudflared\` references in \`docs/\` or \`README.md\`.
- [x] No inbound links to the deleted section anywhere in the repo.
- [x] Auto-generated \`docs/kh_*.md\` files (cobra) do not reference CF — no command help text mentions it.
- [ ] Reviewer sanity-check: \`kh auth login\` against a CF-gated host still works with \`CF_AUTHORIZATION\` set.